### PR TITLE
Fix usage of CURRENT_TIME macro.

### DIFF
--- a/simple.c
+++ b/simple.c
@@ -522,7 +522,7 @@ static int simplefs_create_fs_object(struct inode *dir, struct dentry *dentry,
 
 	inode->i_sb = sb;
 	inode->i_op = &simplefs_inode_ops;
-	inode->i_atime = inode->i_mtime = inode->i_ctime = CURRENT_TIME;
+	inode->i_atime = inode->i_mtime = inode->i_ctime = current_time(inode);
 	inode->i_ino = (count + SIMPLEFS_START_INO - SIMPLEFS_RESERVED_INODES + 1);
 
 	sfs_inode = kmem_cache_alloc(sfs_inode_cachep, GFP_KERNEL);


### PR DESCRIPTION
The `CURRENT_TIME` macro is no longer present in the latest kernel [source](https://marc.info/?i=1491613030-11599-12-git-send-email-deepa.kernel%40gmail.com). I've replaced the usage of the macro with `current_time()` function.

Relevant kernel commit: bfe1c566453a0979c0b3cd3728d0de962272f034