### PR TITLE
fix compile issues

### DIFF
--- a/simple.c
+++ b/simple.c
@@ -17,6 +17,7 @@
 
 #include "super.h"
 
+#define f_dentry f_path.dentry
 /* A super block lock that must be used for any critical section operation on the sb,
  * such as: updating the free_blocks, inodes_count etc. */
 static DEFINE_MUTEX(simplefs_sb_lock);


### PR DESCRIPTION
fix:
simple.c:187:14: error: ‘struct file’ has no member named ‘f_dentry’
  inode = filp->f_dentry->d_inode;
              ^
simple.c:203:14: error: ‘struct file’ has no member named ‘f_dentry’
          filp->f_dentry->d_name.name);
              ^
simple.c:525:2: error: implicit declaration of function ‘current_time’ [-Werror=implicit-function-declaration]
  inode->i_atime = inode->i_mtime = inode->i_ctime = current_time(inode);

Signed-off-by: Barry Song <21cnbao@gmail.com>