### PR TITLE
Backport to kernel version 3.10

### DIFF
--- a/simple.c
+++ b/simple.c
@@ -526,7 +526,7 @@ static int simplefs_create_fs_object(struct inode *dir, struct dentry *dentry,
 
 	inode->i_sb = sb;
 	inode->i_op = &simplefs_inode_ops;
-	inode->i_atime = inode->i_mtime = inode->i_ctime = current_time(inode);
+	inode->i_atime = inode->i_mtime = inode->i_ctime = CURRENT_TIME;
 	inode->i_ino = (count + SIMPLEFS_START_INO - SIMPLEFS_RESERVED_INODES + 1);
 
 	sfs_inode = kmem_cache_alloc(sfs_inode_cachep, GFP_KERNEL);
@@ -639,7 +639,7 @@ static struct inode *simplefs_iget(struct super_block *sb, int ino)
 
 	/* FIXME: We should store these times to disk and retrieve them */
 	inode->i_atime = inode->i_mtime = inode->i_ctime =
-			current_time(inode);
+			CURRENT_TIME;
 
 	inode->i_private = sfs_inode;
 
@@ -875,7 +875,7 @@ int simplefs_fill_super(struct super_block *sb, void *data, int silent)
 	root_inode->i_op = &simplefs_inode_ops;
 	root_inode->i_fop = &simplefs_dir_operations;
 	root_inode->i_atime = root_inode->i_mtime = root_inode->i_ctime =
-	    current_time(root_inode);
+	    CURRENT_TIME;
 
 	root_inode->i_private =
 	    simplefs_get_inode(sb, SIMPLEFS_ROOTDIR_INODE_NUMBER);


### PR DESCRIPTION
This patch backports simplefs to kernel version 3.10.
current_time(struct inode *) was introduced from kernel
version 4.9. This patch backports simplefs to kernel
version 3.10 (Centos 7.5) by replacing current_time()
by CURRENT_TIME macro. The idea is to 'tag' this version
such that is becomes easy to experiment on commanly used
distribution which comes with little dated kernel.

After Patch:
~~~~~~~~~~~~
$ cat /etc/redhat-release
CentOS Linux release 7.5.1804 (Core)

$ make
make -C /lib/modules/3.10.0-957.el7.x86_64/build M=/root/dev_world/simplefs modules
make[1]: Entering directory `/usr/src/kernels/3.10.0-957.el7.x86_64'
  Building modules, stage 2.
  MODPOST 1 modules
make[1]: Leaving directory `/usr/src/kernels/3.10.0-957.el7.x86_64'
$

$ insmod simplefs.ko

$ lsmod | grep simplefs
simplefs               18383  0
jbd2                  107478  2 ext4,simplefs

Signed-off-by: Arshad Hussain <arshad.super@gmail.com>